### PR TITLE
handle SSM-session SIGINT cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 kubectl-node_ssm
 .DS_Store
+.idea

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/VioletCranberry/kubectl-node-ssm
 
 go 1.19
 
-require github.com/spf13/cobra v1.7.0
+require (
+	github.com/spf13/cobra v1.7.0
+	golang.org/x/sys v0.8.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -38,7 +41,6 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
-	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/helpers/ssm_unix.go
+++ b/pkg/helpers/ssm_unix.go
@@ -1,0 +1,53 @@
+//go:build linux || darwin
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+type SSMClient struct {
+	AWSProfile string
+	AWSRegion  string
+	CMD        *exec.Cmd
+}
+
+func (c *SSMClient) SetCMD(targetId string, params []string) {
+	cmdArgs := []string{"ssm", "start-session", "--target", targetId}
+
+	cmdArgs = append(cmdArgs, params...)
+	cmd := exec.Command("aws", cmdArgs...)
+
+	// Put the child processes in the foreground and their own process group to
+	// allow the child process group to capture the Ctrl-C (or SIGINT) signal,
+	// which otherwise would have killed the node-ssm process and its child
+	// processes when they are all in the same process group.
+
+	cmd.SysProcAttr = &unix.SysProcAttr{
+		Foreground: true,
+	}
+
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env,
+		fmt.Sprintf("AWS_PROFILE=%s", c.AWSProfile),
+		fmt.Sprintf("AWS_REGION=%s", c.AWSRegion),
+	)
+	c.CMD = cmd
+}
+
+func (c *SSMClient) RunCMD() {
+
+	c.CMD.Stdin = os.Stdin
+	c.CMD.Stdout = os.Stdout
+	c.CMD.Stderr = os.Stderr
+
+	err := c.CMD.Run()
+	if err != nil {
+		errmsg := fmt.Errorf("can't run local command: %s ", err)
+		panic(errmsg)
+	}
+}

--- a/pkg/helpers/ssm_windows.go
+++ b/pkg/helpers/ssm_windows.go
@@ -1,10 +1,13 @@
+//go:build windows
+
 package helpers
 
 import (
 	"fmt"
 	"os"
 	"os/exec"
-	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 type SSMClient struct {
@@ -19,12 +22,13 @@ func (c *SSMClient) SetCMD(targetId string, params []string) {
 	cmdArgs = append(cmdArgs, params...)
 	cmd := exec.Command("aws", cmdArgs...)
 
-	// Put the child processes in the foreground and their own process group to
-	// allow the child process group to capture the Ctrl-C (or SIGINT) signal,
-	// which otherwise would have killed the node-ssm process and its child
-	// processes when they are all in the same process group.
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Foreground: true,
+	// Probably that will work. Sadly I do not have access
+	// neither to Windows machine nor to SSM-enabled environments
+	// right now.
+
+	cmd.SysProcAttr = &windows.SysProcAttr{
+		CreationFlags:    windows.CREATE_NEW_CONSOLE,
+		NoInheritHandles: true,
 	}
 
 	cmd.Env = os.Environ()


### PR DESCRIPTION
- move away from `syscall` (deprecated/locked down) to `sys`
- handle SSM-session Ctrl-C (or SIGINT) signals for both windows and linux