### PR TITLE
fall back to shared AWS config if AWS_PROFILE was not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,23 +52,18 @@ Flags:
 
 ### Requirements:
 
-1. [`AWS CLI installed`](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
-2. [`AWS session-manager-plugin installed`](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
-3. [`AWS Systems Manager Session Manager configured`](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started.html)
+1. [AWS CLI installed](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
+2. [AWS session-manager-plugin installed](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+3. [AWS Systems Manager Session Manager configured](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started.html)
 4. IAM Permissions to perform `ec2:DescribeInstances`
 
 ### Logic:
 
-1. Return [`kubeconfig`](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html) REST client from current context
-2. Parse [`Config.Host`](https://pkg.go.dev/k8s.io/client-go@v0.26.3/rest#Config.Host) for `AWS_REGION`
-3. Parse [`[]ExecEnvVar`](https://pkg.go.dev/k8s.io/client-go/tools/clientcmd/api#ExecConfig.Env) for `AWS_PROFILE`
-4. Resolve EKS node `private-dns-name` to instance ID using [`AWS describe-instances`](https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.44.239/service/ec2#EC2.DescribeInstances)
-5. Build `aws ssm start-session --target <instance id>` [command](https://pkg.go.dev/os/exec#Command) with specified parameters
-6. Specify environment of the command with `AWS_REGION` and `AWS_PROFILE` variables
-7. Start the command and wait for it to complete
-
-### Notes:
-
-Most likely `aws eks update-kubeconfig --region region-code --name my-cluster` should include `--profile`
-to have `AWS_PROFILE` variable exposed in cluster environment variables of `kubeconfig` file. I did not test it out since `--profile` was always present when I was creating or updating `kubeconfig` file for our clusters.
-
+1. Return [kubeconfig](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html) REST client from current context.
+2. Parse [Config.Host](https://pkg.go.dev/k8s.io/client-go@v0.26.3/rest#Config.Host) for `AWS_REGION`.
+3. Parse [[]ExecEnvVar](https://pkg.go.dev/k8s.io/client-go/tools/clientcmd/api#ExecConfig.Env) for `AWS_PROFILE`.  
+If `AWS_PROFILE` was not found we assume [AWS session](https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/session) is to be created with a Shared Configuration file. 
+4. Resolve EKS node `private-dns-name` to instance ID using [AWS describe-instances](https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.44.239/service/ec2#EC2.DescribeInstances).
+5. Build `aws ssm start-session --target <instance id>` [command](https://pkg.go.dev/os/exec#Command) with specified parameters.
+6. Specify environment of the command with `AWS_REGION` and optional `AWS_PROFILE` variables.
+7. Start the command and wait for it to complete.

--- a/main.go
+++ b/main.go
@@ -17,13 +17,16 @@ func main() {
 		flags := pflag.NewFlagSet("kubectl-node-ssm", pflag.ExitOnError)
 		pflag.CommandLine = flags
 
-		root := cmd.NewSessionCmd(genericclioptions.IOStreams{
+		sessionCmd := cmd.NewSessionCmd(genericclioptions.IOStreams{
 			In:     os.Stdin,
 			Out:    os.Stdout,
 			ErrOut: os.Stderr,
 		})
-		// nolint: errcheck
-		root.Execute()
+		err := sessionCmd.Execute()
+		if err != nil {
+			errmsg := errors.New("was unable to execute cobra session cmd")
+			panic(errmsg)
+		}
 	} else {
 		errmsg := errors.New("was not invoked as kubectl plugin")
 		panic(errmsg)

--- a/pkg/helpers/aws.go
+++ b/pkg/helpers/aws.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/VioletCranberry/kubectl-node-ssm/pkg/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -11,19 +12,43 @@ import (
 )
 
 type AWSClient struct {
-	Client     ec2iface.EC2API
-	AWSProfile string
-	AWSRegion  string
+	Client ec2iface.EC2API
 }
 
-func (c *AWSClient) SetClient() {
+func NewAWSClient(awsProfile, awsRegion string) *AWSClient {
+	client := AWSClient{}
+
+	if utils.ContainsEmpty(awsProfile) {
+		client.SetSharedConfigClient(awsRegion)
+	} else {
+		client.SetClientWithProfile(awsProfile, awsRegion)
+	}
+	return &client
+}
+
+func (c *AWSClient) SetClientWithProfile(awsProfile, awsRegion string) {
 	sess := session.Must(
 		session.NewSessionWithOptions(
 			session.Options{
-				Profile: c.AWSProfile,
+				Profile: awsProfile,
 				Config: aws.Config{
-					Region: aws.String(c.AWSRegion),
+					Region: aws.String(awsRegion),
 				},
+			}),
+	)
+	c.Client = ec2.New(sess)
+}
+
+func (c *AWSClient) SetSharedConfigClient(awsRegion string) {
+	// shared config to be used when AWS_PROFILE was not found in kubeconfig,
+	// AWS_REGION is parsed from cluster hostname so it is always set.
+	sess := session.Must(
+		session.NewSessionWithOptions(
+			session.Options{
+				Config: aws.Config{
+					Region: aws.String(awsRegion),
+				},
+				SharedConfigState: session.SharedConfigEnable,
 			}),
 	)
 	c.Client = ec2.New(sess)

--- a/pkg/helpers/aws_test.go
+++ b/pkg/helpers/aws_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	ec2 "github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
 
@@ -13,7 +13,7 @@ type mockEC2Client struct {
 	Res ec2.DescribeInstancesOutput
 }
 
-func (m mockEC2Client) DescribeInstances(in *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+func (m mockEC2Client) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 	return &m.Res, nil
 }
 
@@ -57,20 +57,6 @@ func Test_GetInstanceData(t *testing.T) {
 	}
 }
 
-func Test_GetInstanceDataPanic(t *testing.T) {
-	testAwsClient := AWSClient{
-		Client: mockEC2Client{
-			Res: ec2.DescribeInstancesOutput{},
-		},
-	}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("the code did not panic")
-		}
-	}()
-	testAwsClient.GetInstanceData("test")
-}
-
 func Test_ParseInstanceData(t *testing.T) {
 	type testCases struct {
 		res        ec2.DescribeInstancesOutput
@@ -102,6 +88,20 @@ func Test_ParseInstanceData(t *testing.T) {
 				scenario.instanceId, instanceId)
 		}
 	}
+}
+
+func Test_GetInstanceDataPanic(t *testing.T) {
+	testAwsClient := AWSClient{
+		Client: mockEC2Client{
+			Res: ec2.DescribeInstancesOutput{},
+		},
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("the code did not panic")
+		}
+	}()
+	testAwsClient.GetInstanceData("test")
 }
 
 func Test_ParseInstanceDataPanic(t *testing.T) {

--- a/pkg/helpers/k8s.go
+++ b/pkg/helpers/k8s.go
@@ -9,30 +9,36 @@ import (
 
 type KubeConfig struct {
 	Config     *rest.Config
-	AWSProfile string
-	AWSRegion  string
+	AwsProfile string
+	AwsRegion  string
 }
 
-func (k *KubeConfig) SetProfile() {
-	errmsg := fmt.Errorf("can't parse AWS_PROFILE from %v",
-		k.Config.ExecProvider.Env)
+func NewKubeConfig(config *rest.Config) *KubeConfig {
+	kubeConfig := KubeConfig{
+		Config: config,
+	}
+	kubeConfig.setAwsRegion()
+	kubeConfig.setAwsProfile()
+	return &kubeConfig
+}
+
+func (k *KubeConfig) setAwsProfile() {
+	// AWS_PROFILE can be empty if user is not providing AWS_PROFILE var (e.g. using default profile)
+	var awsProfile string
 	for _, envvar := range k.Config.ExecProvider.Env {
 		if envvar.Name == "AWS_PROFILE" {
-			k.AWSProfile = envvar.Value
+			awsProfile = envvar.Value
 		}
 	}
-	if k.AWSProfile == "" {
-		panic(errmsg)
-	}
+	k.AwsProfile = awsProfile
 }
 
-func (k *KubeConfig) SetRegion() {
+func (k *KubeConfig) setAwsRegion() {
 	re := regexp.MustCompile(`\w+-(gov-)?\w+-\d+`)
-	errmsg := fmt.Errorf("can't parse AWS_REGION from %s",
-		k.Config.Host)
+	errmsg := fmt.Errorf("can't parse AWS_REGION from %s", k.Config.Host)
 	AWSregion := re.FindString(k.Config.Host)
 	if AWSregion != "" {
-		k.AWSRegion = AWSregion
+		k.AwsRegion = AWSregion
 	} else {
 		panic(errmsg)
 	}

--- a/pkg/helpers/k8s_test.go
+++ b/pkg/helpers/k8s_test.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-func Test_SetRegion(t *testing.T) {
+func Test_setAwsRegion(t *testing.T) {
 	type testCases struct {
 		config         *KubeConfig
 		expectedRegion string
@@ -28,29 +28,15 @@ func Test_SetRegion(t *testing.T) {
 			expectedRegion: "us-gov-east-1",
 		},
 	} {
-		scenario.config.SetRegion()
-		if scenario.expectedRegion != scenario.config.AWSRegion {
+		scenario.config.setAwsRegion()
+		if scenario.expectedRegion != scenario.config.AwsRegion {
 			t.Errorf("set invalid region: expected %s / got %s",
-				scenario.expectedRegion, scenario.config.AWSRegion)
+				scenario.expectedRegion, scenario.config.AwsRegion)
 		}
 	}
 }
 
-func Test_SetRegionPanic(t *testing.T) {
-	testConfig := KubeConfig{
-		Config: &rest.Config{
-			Host: "",
-		},
-	}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("the code did not panic")
-		}
-	}()
-	testConfig.SetRegion()
-}
-
-func Test_SetProfile(t *testing.T) {
+func Test_setAwsProfile(t *testing.T) {
 	type testCases struct {
 		config          *KubeConfig
 		expectedProfile string
@@ -73,33 +59,30 @@ func Test_SetProfile(t *testing.T) {
 		{
 			config: &KubeConfig{Config: &rest.Config{
 				ExecProvider: &api.ExecConfig{
-					Env: []api.ExecEnvVar{
-						{
-							Name:  "AWS_PROFILE",
-							Value: "test-profile-2",
-						},
-					},
+					Env: nil,
 				},
 			}},
-			expectedProfile: "test-profile-2",
+			expectedProfile: "",
 		},
 	} {
-		scenario.config.SetProfile()
-		if scenario.expectedProfile != scenario.config.AWSProfile {
+		scenario.config.setAwsProfile()
+		if scenario.expectedProfile != scenario.config.AwsProfile {
 			t.Errorf("set invalid profile: expected %s / got %s",
-				scenario.expectedProfile, scenario.config.AWSProfile)
+				scenario.expectedProfile, scenario.config.AwsProfile)
 		}
 	}
 }
 
-func Test_SetProfilePanic(t *testing.T) {
+func Test_setAwsRegionPanic(t *testing.T) {
 	testConfig := KubeConfig{
-		Config: &rest.Config{},
+		Config: &rest.Config{
+			Host: "",
+		},
 	}
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("the code did not panic")
 		}
 	}()
-	testConfig.SetProfile()
+	testConfig.setAwsRegion()
 }

--- a/pkg/helpers/ssm_windows.go
+++ b/pkg/helpers/ssm_windows.go
@@ -7,13 +7,12 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/VioletCranberry/kubectl-node-ssm/pkg/utils"
 	"golang.org/x/sys/windows"
 )
 
 type SSMClient struct {
-	AWSProfile string
-	AWSRegion  string
-	CMD        *exec.Cmd
+	CMD *exec.Cmd
 }
 
 func (c *SSMClient) SetCMD(targetId string, params []string) {
@@ -30,17 +29,22 @@ func (c *SSMClient) SetCMD(targetId string, params []string) {
 		CreationFlags:    windows.CREATE_NEW_CONSOLE,
 		NoInheritHandles: true,
 	}
-
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env,
-		fmt.Sprintf("AWS_PROFILE=%s", c.AWSProfile),
-		fmt.Sprintf("AWS_REGION=%s", c.AWSRegion),
-	)
 	c.CMD = cmd
 }
 
-func (c *SSMClient) RunCMD() {
+func (c *SSMClient) SetEnv(awsProfile, awsRegion string) {
+	c.CMD.Env = os.Environ()
+	// aws region is always defined at this stage
+	c.CMD.Env = append(c.CMD.Env, fmt.Sprintf("AWS_REGION=%s", awsRegion))
 
+	if !utils.ContainsEmpty(awsProfile) {
+		c.CMD.Env = append(c.CMD.Env,
+			fmt.Sprintf("AWS_PROFILE=%s", awsProfile),
+		)
+	}
+}
+
+func (c *SSMClient) RunCMD() {
 	c.CMD.Stdin = os.Stdin
 	c.CMD.Stdout = os.Stdout
 	c.CMD.Stderr = os.Stderr

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,10 @@
+package utils
+
+func ContainsEmpty(ss ...string) bool {
+	for _, s := range ss {
+		if s == "" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- make AWS_PROFILE as optional variable
- fall back to AWS Session with SharedConfig enabled if AWS_PROFILE was not found in kubeconfig file
- set AWS_PROFILE as SSM command env var only if string is a non-empty type
- adjust tests to reflect new behavior
- adjust README.md