### PR TITLE
adjust to Go's naming conventions

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -26,6 +26,10 @@ jobs:
         name: Setup go environment
         with:
           go-version: "1.20"
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          install-only: true
 
       - name: Run tests
         run: go test -v ./...
@@ -33,4 +37,7 @@ jobs:
         name: Run golangci-lint
         with:
           version: "latest"
-          args: --timeout=2m --verbose
+          args: --enable revive --timeout=2m --verbose
+      - name: Build libraries
+        run: |
+          ./build.sh --snapshot

--- a/build.sh
+++ b/build.sh
@@ -1,20 +1,41 @@
 #!/bin/bash
 set -euxo pipefail
 
-checksum_command=""
+snapshot='false'
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -s|--snapshot)
+            snapshot='true'
+            shift
+            ;;
+        *)
+            echo "usage: $0 [-s | --snapshot]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+checksum_cmd=""
 # common on macOS
 if command -v shasum >/dev/null 2>&1; then
-    checksum_command="shasum -a 256"
+    checksum_cmd="shasum -a 256"
 # common on Linux
 elif command -v sha256sum >/dev/null 2>&1; then
-    checksum_command="sha256sum"
+    checksum_cmd="sha256sum"
 fi
 
-goreleaser release --timeout=10m --auto-snapshot --fail-fast --clean --skip=publish
+goreleaser_base_cmd='goreleaser release --timeout=10m --fail-fast --clean --skip=publish'
+if [ "$snapshot" = "true" ]; then
+    goreleaser_cmd="$goreleaser_base_cmd --snapshot"
+else
+    goreleaser_cmd="$goreleaser_base_cmd --auto-snapshot"
+fi
+
+$goreleaser_cmd
 cd dist || exit 1
 
 for archive in *.tar.gz *.zip; do
   if [ -f "$archive" ]; then
-    $checksum_command "$archive" > "$archive.sha256"
+    $checksum_cmd "$archive" > "$archive.sha256"
   fi
 done

--- a/cmd/startSession.go
+++ b/cmd/startSession.go
@@ -18,11 +18,11 @@ func newStartSessionCmd(opts *cliOptions, target *string, params *[]string) *cob
 			if err != nil {
 				return fmt.Errorf("error reading kubeconfig file: %w", err)
 			}
-			instanceId, err := resolveTargetToId(kubeConfig.AwsProfile, kubeConfig.AwsRegion, *target)
+			instanceID, err := resolveTargetToID(kubeConfig.AwsProfile, kubeConfig.AwsRegion, *target)
 			if err != nil {
 				return fmt.Errorf("error resolving target node name to instance ID: %w", err)
 			}
-			err = newSSMsession(kubeConfig.AwsProfile, kubeConfig.AwsRegion, instanceId, *params)
+			err = newSsmSession(kubeConfig.AwsProfile, kubeConfig.AwsRegion, instanceID, *params)
 			if err != nil {
 				return fmt.Errorf("error starting new SSM session: %w", err)
 			}
@@ -45,8 +45,8 @@ func readKubeConfig(opts *cliOptions) (*helpers.KubeConfig, error) {
 	return kubeConfig, nil
 }
 
-func resolveTargetToId(awsProfile, awsRegion, target string) (string, error) {
-	client, err := helpers.NewAWSClient(awsProfile, awsRegion)
+func resolveTargetToID(awsProfile, awsRegion, target string) (string, error) {
+	client, err := helpers.NewAwsClient(awsProfile, awsRegion)
 	if err != nil {
 		return "", fmt.Errorf("error setting up AWS client: %w", err)
 	}
@@ -54,19 +54,19 @@ func resolveTargetToId(awsProfile, awsRegion, target string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error getting instance data for target %s: %w", target, err)
 	}
-	instanceId, err := helpers.ParseInstanceData(instanceData)
+	instanceID, err := helpers.ParseInstanceData(instanceData)
 	if err != nil {
 		return "", fmt.Errorf("error parsing instance data for target %s: %w", target, err)
 	}
-	return instanceId, nil
+	return instanceID, nil
 }
 
-func newSSMsession(awsProfile, awsRegion, instanceId string, params []string) error {
-	client, err := helpers.NewSSMClient(instanceId, params, awsProfile, awsRegion)
+func newSsmSession(awsProfile, awsRegion, instanceID string, params []string) error {
+	client, err := helpers.NewSsmClient(instanceID, params, awsProfile, awsRegion)
 	if err != nil {
 		return fmt.Errorf("error setting up SSM client: %w", err)
 	}
-	err = client.RunCMD()
+	err = client.RunCmd()
 	if err != nil {
 		return fmt.Errorf("error running SSM session command: %w", err)
 	}

--- a/pkg/helpers/aws.go
+++ b/pkg/helpers/aws.go
@@ -10,22 +10,22 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
 
-type AWSClient struct {
+type AwsClient struct {
 	Client ec2iface.EC2API
 }
 
-func NewAWSClient(awsProfile, awsRegion string) (*AWSClient, error) {
-	sess, err := createAWSSession(awsProfile, awsRegion)
+func NewAwsClient(awsProfile, awsRegion string) (*AwsClient, error) {
+	sess, err := createAwsSession(awsProfile, awsRegion)
 	if err != nil {
 		return nil, err
 	}
 
-	return &AWSClient{
+	return &AwsClient{
 		Client: ec2.New(sess),
 	}, nil
 }
 
-func createAWSSession(awsProfile, awsRegion string) (*session.Session, error) {
+func createAwsSession(awsProfile, awsRegion string) (*session.Session, error) {
 	var opts session.Options
 
 	if awsProfile == "" {
@@ -47,12 +47,12 @@ func createAWSSession(awsProfile, awsRegion string) (*session.Session, error) {
 	return session.NewSessionWithOptions(opts)
 }
 
-func (c *AWSClient) GetInstanceData(privateDnsName string) (*ec2.DescribeInstancesOutput, error) {
+func (c *AwsClient) GetInstanceData(privateDNSName string) (*ec2.DescribeInstancesOutput, error) {
 	res, err := c.Client.DescribeInstances(&ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("private-dns-name"),
-				Values: []*string{aws.String(privateDnsName)},
+				Values: []*string{aws.String(privateDNSName)},
 			},
 			{
 				Name:   aws.String("instance-state-name"),
@@ -64,7 +64,7 @@ func (c *AWSClient) GetInstanceData(privateDnsName string) (*ec2.DescribeInstanc
 		return nil, fmt.Errorf("error describing instances: %w", err)
 	}
 	if res.Reservations == nil || len(res.Reservations) == 0 {
-		return nil, fmt.Errorf("no instance data found for %s", privateDnsName)
+		return nil, fmt.Errorf("no instance data found for %s", privateDNSName)
 	}
 	return res, nil
 }

--- a/pkg/helpers/aws_test.go
+++ b/pkg/helpers/aws_test.go
@@ -21,15 +21,15 @@ func (m *MockEC2Client) DescribeInstances(input *ec2.DescribeInstancesInput) (*e
 	return args.Get(0).(*ec2.DescribeInstancesOutput), args.Error(1)
 }
 
-func TestNewAWSClient(t *testing.T) {
-	client, err := NewAWSClient("", "us-west-2")
+func TestNewAwsClient(t *testing.T) {
+	client, err := NewAwsClient("", "us-west-2")
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 }
 
 func TestGetInstanceData(t *testing.T) {
 	mockEc2 := new(MockEC2Client)
-	testClient := &AWSClient{Client: mockEc2}
+	testClient := &AwsClient{Client: mockEc2}
 
 	dnsName := "ip-10-0-0-1.ec2.internal"
 	expectedOutput := &ec2.DescribeInstancesOutput{
@@ -59,7 +59,7 @@ func TestGetInstanceData(t *testing.T) {
 
 func TestGetInstanceDataWithError(t *testing.T) {
 	mockEc2 := new(MockEC2Client)
-	testClient := &AWSClient{Client: mockEc2}
+	testClient := &AwsClient{Client: mockEc2}
 
 	dnsName := "nonexistent.ec2.internal"
 	mockEc2.On("DescribeInstances", mock.Anything).Return((*ec2.DescribeInstancesOutput)(nil), errors.New("instance not found"))

--- a/pkg/helpers/ssm_test.go
+++ b/pkg/helpers/ssm_test.go
@@ -7,7 +7,7 @@ import (
 
 var mockExecCommand func(name string, arg ...string) *exec.Cmd
 
-func TestNewSSMClient(t *testing.T) {
+func TestNewSsmClient(t *testing.T) {
 	mockExecCommand = func(name string, arg ...string) *exec.Cmd {
 		return &exec.Cmd{}
 	}
@@ -18,7 +18,7 @@ func TestNewSSMClient(t *testing.T) {
 	awsProfile := "test-profile"
 	awsRegion := "test-region"
 
-	client, err := NewSSMClient(targetID, params, awsProfile, awsRegion)
+	client, err := NewSsmClient(targetID, params, awsProfile, awsRegion)
 	if err != nil {
 		t.Fatalf("NewSSMClient() error = %v, wantErr %v", err, nil)
 	}

--- a/pkg/helpers/ssm_unix.go
+++ b/pkg/helpers/ssm_unix.go
@@ -10,14 +10,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type SSMClient struct {
+type SsmClient struct {
 	Cmd *exec.Cmd
 }
 
-func NewSSMClient(targetId string, params []string,
-	awsProfile, awsRegion string) (*SSMClient, error) {
-	client := &SSMClient{}
-	cmd, err := client.buildCMD(targetId, params)
+func NewSsmClient(targetID string, params []string,
+	awsProfile, awsRegion string) (*SsmClient, error) {
+	client := &SsmClient{}
+	cmd, err := client.buildCmd(targetID, params)
 	if err != nil {
 		return nil, fmt.Errorf("error building command: %w", err)
 	}
@@ -28,15 +28,15 @@ func NewSSMClient(targetId string, params []string,
 	return client, nil
 }
 
-func (c *SSMClient) buildCMD(targetId string, params []string) (*exec.Cmd, error) {
-	cmdArgs := append([]string{"ssm", "start-session", "--target", targetId}, params...)
+func (c *SsmClient) buildCmd(targetID string, params []string) (*exec.Cmd, error) {
+	cmdArgs := append([]string{"ssm", "start-session", "--target", targetID}, params...)
 	cmd := exec.Command("aws", cmdArgs...)
 
 	cmd.SysProcAttr = &unix.SysProcAttr{Foreground: true}
 	return cmd, nil
 }
 
-func (c *SSMClient) setEnv(awsProfile, awsRegion string) {
+func (c *SsmClient) setEnv(awsProfile, awsRegion string) {
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("AWS_REGION=%s", awsRegion))
 	if awsProfile != "" {
@@ -45,7 +45,7 @@ func (c *SSMClient) setEnv(awsProfile, awsRegion string) {
 	c.Cmd.Env = env
 }
 
-func (c *SSMClient) RunCMD() error {
+func (c *SsmClient) RunCmd() error {
 	c.Cmd.Stdin = os.Stdin
 	c.Cmd.Stdout = os.Stdout
 	c.Cmd.Stderr = os.Stderr

--- a/pkg/helpers/ssm_windows.go
+++ b/pkg/helpers/ssm_windows.go
@@ -10,13 +10,14 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-type SSMClient struct {
+type SsmClient struct {
 	Cmd *exec.Cmd
 }
 
-func NewSSMClient(targetId string, params []string, awsProfile, awsRegion string) (*SSMClient, error) {
-	client := &SSMClient{}
-	cmd, err := client.buildCMD(targetId, params)
+func NewSsmClient(targetID string, params []string,
+	awsProfile, awsRegion string) (*SsmClient, error) {
+	client := &SsmClient{}
+	cmd, err := client.buildCmd(targetID, params)
 	if err != nil {
 		return nil, fmt.Errorf("error building command: %w", err)
 	}
@@ -27,8 +28,8 @@ func NewSSMClient(targetId string, params []string, awsProfile, awsRegion string
 	return client, nil
 }
 
-func (c *SSMClient) buildCMD(targetId string, params []string) (*exec.Cmd, error) {
-	cmdArgs := append([]string{"ssm", "start-session", "--target", targetId}, params...)
+func (c *SsmClient) buildCmd(targetID string, params []string) (*exec.Cmd, error) {
+	cmdArgs := append([]string{"ssm", "start-session", "--target", targetID}, params...)
 	cmd := exec.Command("aws", cmdArgs...)
 
 	cmd.SysProcAttr = &windows.SysProcAttr{
@@ -38,7 +39,7 @@ func (c *SSMClient) buildCMD(targetId string, params []string) (*exec.Cmd, error
 	return cmd, nil
 }
 
-func (c *SSMClient) setEnv(awsProfile, awsRegion string) {
+func (c *SsmClient) setEnv(awsProfile, awsRegion string) {
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("AWS_REGION=%s", awsRegion))
 	if awsProfile != "" {
@@ -47,7 +48,7 @@ func (c *SSMClient) setEnv(awsProfile, awsRegion string) {
 	c.Cmd.Env = env
 }
 
-func (c *SSMClient) RunCMD() error {
+func (c *SsmClient) RunCmd() error {
 	c.Cmd.Stdin = os.Stdin
 	c.Cmd.Stdout = os.Stdout
 	c.Cmd.Stderr = os.Stderr


### PR DESCRIPTION
1. adjust function names based on Go's naming conventions
2. enable build as a part of merge request workflow